### PR TITLE
fix runkit node error @RTT-008

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "react-time-textfield",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Material UI TextField with controlled hour/minute/meridiem input",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.es.js",
-  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
Fix for runKit error: 

_NodeError: Must use import to load ES Module: /app/available_modules/1676916569000/react-time-textfield/dist/index.js
require() of ES modules is not supported.
require() of /app/available_modules/1676916569000/react-time-textfield/dist/index.js from /app/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules._
_**Instead rename /app/available_modules/1676916569000/react-time-textfield/dist/index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /app/available_modules/1676916569000/react-time-textfield/package.json.**_